### PR TITLE
Fix missing IMAGE_NAME from deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ executors:
     docker:
       - image: omisegoimages/ewallet-deploy:stable
     working_directory: ~/src
-
+    environment:
+      IMAGE_NAME: "omisego/potterhat"
 
 commands:
   setup_workspace:


### PR DESCRIPTION
Issue/Task Number: -

# Overview

Fix missing IMAGE_NAME env var from circleci's deploy step.

# Changes

- Add `IMAGE_NAME` to deploy executor

# Implementation Details

Add `IMAGE_NAME` to fix the error:

```
sh .circleci/ci_deploy.sh

#!/bin/bash -eo pipefail
  sh .circleci/ci_deploy.sh

IMAGE_NAME has not been set.
Exited with code 1
```

# Usage

N/A

# Impact

N/A