### PR TITLE
Add foreground and console to rootfs/entrypoint

### DIFF
--- a/rootfs/entrypoint
+++ b/rootfs/entrypoint
@@ -54,6 +54,11 @@ s6-env HOME=/app
 ##
 s6-env REPLACE_OS_VARS=yes
 
+## Known commands
+##
+ifelse { test $1 == "foreground" } { /app/bin/potterhat $@ }
+ifelse { test $1 == "console" } { /app/bin/potterhat $@ }
+
 ## Fallback; if we're not running the known command, just run it as is.
 ## This is to allow e.g. administrator attaching a shell into the container.
 ##


### PR DESCRIPTION
Issue/Task Number: #10

# Overview

Add missing known commands to rootfs/entrypoint so docker image can be started properly

# Changes

- Add `foreground` and `console` to rootfs/entrypoint

# Implementation Details

N/A

# Usage

`docker run omisego/potterhat:latest` should now work.

# Impact

N/A