### PR TITLE
Fix conflicting build vs. release image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM alpine:3.8
 
 LABEL maintainer="OmiseGO Team <omg@omise.co>"
 LABEL description="Official image for OmiseGO Potterhat"
@@ -11,26 +11,25 @@ ENV LANG=C.UTF-8
 ENV S6_VERSION="1.21.4.0"
 
 RUN set -xe \
- && apt-get update \
- && apt-get install -y \
-                    curl \
-                    ca-certificates \
+ && apk add --update --no-cache --virtual .fetch-deps \
+        curl \
+        ca-certificates \
  && S6_DOWNLOAD_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz" \
  && S6_DOWNLOAD_SHA256="e903f138dea67e75afc0f61e79eba529212b311dc83accc1e18a449d58a2b10c" \
  && curl -fsL -o s6-overlay.tar.gz "${S6_DOWNLOAD_URL}" \
  && echo "${S6_DOWNLOAD_SHA256}  s6-overlay.tar.gz" |sha256sum -c - \
  && tar -xzC / -f s6-overlay.tar.gz \
  && rm s6-overlay.tar.gz \
- && rm -rf /var/lib/apt/lists/*
+ && apk del .fetch-deps
 
 ## Application
 ##
 
-RUN set -xe \
- && apt-get update \
- && apt-get install -y \
-                    bash \
- && rm -rf /var/lib/apt/lists/*
+RUN apk add --update --no-cache --virtual .potterhat-runtime \
+        bash \
+        libressl \
+        libressl-dev \
+        lksctp-tools
 
 COPY rootfs /
 
@@ -42,14 +41,8 @@ ARG uid=10000
 ARG gid=10000
 
 RUN set -xe \
- && groupadd --gid "${gid}" "${group}" \
- && useradd \
-      --uid ${uid} \
-      --gid ${gid} \
-      --home /app \
-      --create-home \
-      --shell /bin/bash \
-      ${user} \
+ && addgroup -g ${gid} ${group} \
+ && adduser -D -h /app -u ${uid} -G ${group} ${user} \
  && chown "${uid}:${gid}" "/app" \
  && chmod +x /entrypoint
 


### PR DESCRIPTION
Issue/Task Number: #10

# Overview

This PR uses alpine as docker base image to quickly get potterhat up and running (since the builders are alpine-based).

# Changes

- Switch back to alpine

# Implementation Details

Once the alpine/ubuntu discussion is concluded, we can still switch potterhat quite easily as it requires only Dockerfile change, while most of prerequisite work will be required to prepare the CI environment so it's better to unblock potterhat from the ongoing discussion.

# Usage

The docker image after this PR should be able to deploy successfully.

# Impact

Affects CI and deployment process.