### PR TITLE
Make publish step a prerequisite before deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ workflows:
           requires: [lint, test, dialyze]
           filters: *all_branches
       - deploy:
-          requires: [build]
+          requires: [publish]
           filters:
             branches:
               only:


### PR DESCRIPTION
Issue/Task Number: #10

# Overview

Make CI publish step a prerequisite for CI deploy step.

# Changes

- Make circleci's `deploy` require `publish` instead of `build`

# Implementation Details

Deploy should be after publish so that the image is ready before deployment

# Usage

N/A

# Impact

N/A