### PR TITLE
Fix batch JSON-RPC request support

### DIFF
--- a/apps/potterhat_node/test/support/mock_ethereum_node/rpc.ex
+++ b/apps/potterhat_node/test/support/mock_ethereum_node/rpc.ex
@@ -36,8 +36,16 @@ defmodule PotterhatNode.MockEthereumNode.RPC do
     send_resp(conn, 200, "Invalid request")
   end
 
-  def generate_response(conn) do
-    conn.body_params
+  def generate_response(%{body_params: batch_params} = conn) when is_list(batch_params) do
+    Enum.map(batch_params, fn body_params -> generate_response(body_params, conn) end)
+  end
+
+  def generate_response(%{body_params: body_params} = conn) do
+    generate_response(body_params, conn)
+  end
+
+  def generate_response(body_params, conn) do
+    body_params
     |> Map.fetch!("method")
     |> do_generate_response(conn)
   end

--- a/apps/potterhat_node/test/support/mock_ethereum_node/rpc.ex
+++ b/apps/potterhat_node/test/support/mock_ethereum_node/rpc.ex
@@ -36,7 +36,7 @@ defmodule PotterhatNode.MockEthereumNode.RPC do
     send_resp(conn, 200, "Invalid request")
   end
 
-  def generate_response(%{body_params: batch_params} = conn) when is_list(batch_params) do
+  def generate_response(%{body_params: %{"_json" => batch_params}} = conn) do
     Enum.map(batch_params, fn body_params -> generate_response(body_params, conn) end)
   end
 

--- a/apps/potterhat_rpc/test/potterhat_rpc/router_test.exs
+++ b/apps/potterhat_rpc/test/potterhat_rpc/router_test.exs
@@ -84,6 +84,12 @@ defmodule PotterhatRPC.RouterTest do
             "method" => "web3_clientVersion",
             "params" => [],
             "id" => :rand.uniform(999)
+          },
+          %{
+            "jsonrpc" => "2.0",
+            "method" => "web3_clientVersion",
+            "params" => [],
+            "id" => :rand.uniform(999)
           }
         ]}
 
@@ -93,7 +99,7 @@ defmodule PotterhatRPC.RouterTest do
         |> json_response()
 
       # The response should be from PotterhatNode.MockEthereumNode.RPC
-      assert response["result"] == "PotterhatMockEthereumNode"
+      assert Enum.all?(response, fn resp -> resp["result"] == "PotterhatMockEthereumNode" end)
     end
 
     test "returns an error response when received an error from forwarding" do

--- a/apps/potterhat_rpc/test/potterhat_rpc/router_test.exs
+++ b/apps/potterhat_rpc/test/potterhat_rpc/router_test.exs
@@ -76,6 +76,26 @@ defmodule PotterhatRPC.RouterTest do
       assert response["result"] == "PotterhatMockEthereumNode"
     end
 
+    test "parses Phoenix-added '_json' key properly" do
+      body_params =
+        %{"_json" => [
+          %{
+            "jsonrpc" => "2.0",
+            "method" => "web3_clientVersion",
+            "params" => [],
+            "id" => :rand.uniform(999)
+          }
+        ]}
+
+      response =
+        Router
+        |> call(:post, "/", body_params)
+        |> json_response()
+
+      # The response should be from PotterhatNode.MockEthereumNode.RPC
+      assert response["result"] == "PotterhatMockEthereumNode"
+    end
+
     test "returns an error response when received an error from forwarding" do
       body_params = %{
         "jsonrpc" => "2.0",

--- a/apps/potterhat_rpc/test/potterhat_rpc/router_test.exs
+++ b/apps/potterhat_rpc/test/potterhat_rpc/router_test.exs
@@ -77,8 +77,8 @@ defmodule PotterhatRPC.RouterTest do
     end
 
     test "parses Phoenix-added '_json' key properly" do
-      body_params =
-        %{"_json" => [
+      body_params = %{
+        "_json" => [
           %{
             "jsonrpc" => "2.0",
             "method" => "web3_clientVersion",
@@ -91,7 +91,8 @@ defmodule PotterhatRPC.RouterTest do
             "params" => [],
             "id" => :rand.uniform(999)
           }
-        ]}
+        ]
+      }
 
       response =
         Router


### PR DESCRIPTION
Issue/Task Number: -

# Overview

This PR fixes the error when Potterhat receives a JSON-RPC batch request.

This bug was found while integrating Potterhat with [omisego/ewallet](https://github.com/omisego/ewallet)'s `eth-blockchain` branch.

# Changes

- Updated `PotterhatRPC.Router`

# Implementation Details

When Phoenix receives a JSON array as body params, it wraps those params in a `%{"_json" => _}` map before passing it to the router. So an extra condition is added to support this quirk.

# Usage

Try send a batch request to Potterhat. E.g.

```shell
curl -X POST http://localhost:8545 \
-H "Content-Type: application/json" \
--data '[
  {
    "id" => 1001,
    "jsonrpc" => "2.0",
    "method" => "eth_getBalance",
    "params" => ["0x0000000000000000000000000000000000000001", "latest"]
  },
  {
    "id" => 1002,
    "jsonrpc" => "2.0",
    "method" => "eth_getBalance",
    "params" => ["0x0000000000000000000000000000000000000002", "latest"]
  }
]'
```

A successful response should be returned instead of an internal server error.

# Impact

No changes to API or DB.